### PR TITLE
Algorithmic improvements

### DIFF
--- a/benchmark.config.js
+++ b/benchmark.config.js
@@ -7,7 +7,8 @@ if (isNode) {
 			process.stdout.write(`${evt.target.name}...`);
 		},
 		onComplete(evt){
-			process.stdout.write(` complete: ${evt.target.hz}\n`);
+			const ops = Math.floor(evt.target.hz);
+			process.stdout.write(` complete: ${Benchmark.formatNumber(ops)} ops/sec (${evt.target.count} samples)\n`);
 		},
 		onCycle(evt){},
 		onError(evt){},

--- a/lib/deePool.src.js
+++ b/lib/deePool.src.js
@@ -9,149 +9,50 @@
 	else { context[name] = definition(name,context); }
 })("deePool",this,function DEF(name,context){
 	"use strict";
-
-	const EMPTY_SLOT = Object.freeze(Object.create(null));
-	const NOTHING = EMPTY_SLOT;
-
-	return { create };
-
+	
+  return { create };
 
 	// ******************************
 
 	// create a new pool
 	function create(objectFactory = ()=>({})) {
-		var objPool = [];
-		var nextFreeSlot = null;	// pool location to look for a free object to use
-		var nextOpenSlot = null;	// pool location to insert next recycled object
-
-		return {
+		var freePool = [];
+    var freePoolEnd = -1;
+		
+    return {
 			use,
 			recycle,
 			grow,
 			size,
 		};
 
-
 		// ******************************
 
 		function use() {
-			var objToUse = NOTHING;
-
-			// know where the next free object in the pool is?
-			if (nextFreeSlot != null) {
-				objToUse = objPool[nextFreeSlot];
-				objPool[nextFreeSlot] = EMPTY_SLOT;
-			}
-			// otherwise, go looking
-			else {
-				// search starts with position + 1 (so, 0)
-				nextFreeSlot = -1;
-			}
-
-			// look for the next free obj
-			for (
-				var count = 0, i = nextFreeSlot + 1;
-				(count < objPool.length) && (i < objPool.length);
-				i = (i + 1) % objPool.length, count++
-			) {
-				// found free obj?
-				if (objPool[i] !== EMPTY_SLOT) {
-					// still need to free an obj?
-					if (objToUse === NOTHING) {
-						objToUse = objPool[i];
-						objPool[i] = EMPTY_SLOT;
-					}
-					// this slot's obj can be used next time
-					else {
-						nextFreeSlot = i;
-						return objToUse;
-					}
-				}
-			}
-
-			// no other free objs left
-			nextFreeSlot = null;
-
-			// still haven't found a free obj to use?
-			if (objToUse === NOTHING) {
-				// double the pool size (or minimum 5 if empty)
-				grow(objPool.length || 5);
-
-				objToUse = objPool[nextFreeSlot];
-				objPool[nextFreeSlot] = EMPTY_SLOT;
-				nextFreeSlot++;
-			}
-
-			return objToUse;
+      if (freePoolEnd == -1) {
+        if (freePool.length == 0) {
+          grow(5);
+        } else {
+          grow();
+        }
+      }
+      return freePool[freePool.length - (freePoolEnd--)];
 		}
 
 		function recycle(obj) {
-			// know where the next empty slot in the pool is?
-			if (nextOpenSlot != null) {
-				objPool[nextOpenSlot] = obj;
-				obj = NOTHING;
-			}
-			// otherwise, go looking
-			else {
-				// search starts with position + 1 (so, 0)
-				nextOpenSlot = -1;
-			}
-
-			// look for the next empty slot
-			for (
-				var count = 0, i = nextOpenSlot + 1;
-				(count < objPool.length) && (i < objPool.length);
-				i = (i + 1) % objPool.length, count++
-			) {
-				// found empty slot?
-				if (objPool[i] === EMPTY_SLOT) {
-					// obj still needs to be reinserted?
-					if (obj !== NOTHING) {
-						objPool[i] = obj;
-						obj = NOTHING;
-					}
-					// this empty slot can be used next time!
-					else {
-						nextOpenSlot = i;
-						return;
-					}
-				}
-			}
-
-			// no empty slots left
-			nextOpenSlot = null;
-
-			// still haven't recycled obj?
-			if (obj !== NOTHING) {
-				// insert at the end (growing size of pool by 1)
-				// NOTE: this is likely mis-use of the library
-				objPool[objPool.length] = obj;
-			}
+      freePool[freePool.length - (++freePoolEnd)] = obj;
 		}
 
-		function grow(count = objPool.length) {
-			nextFreeSlot = objPool.length;
-
-			for (var i = 0; i < count; i++) {
-				// add new obj to pool
-				objPool[objPool.length] = objectFactory();
-			}
-
-			// look for an open slot
-			nextOpenSlot = null;
-			for (var i = 0; i < nextFreeSlot; i++) {
-				// found an open slot?
-				if (objPool[i] === EMPTY_SLOT) {
-					nextOpenSlot = i;
-					break;
-				}
-			}
-
-			return objPool.length;
+		function grow(count = freePool.length) {
+      for (var i = 0; i < count; ++i) {
+        freePool[freePool.length] = objectFactory();
+      }
+      freePoolEnd += count;
+			return freePool.length;
 		}
 
 		function size() {
-			return objPool.length;
+			return freePool.length;
 		}
 	}
 

--- a/lib/deePool.src.js
+++ b/lib/deePool.src.js
@@ -10,16 +10,16 @@
 })("deePool",this,function DEF(name,context){
 	"use strict";
 	
-  return { create };
+	return { create };
 
 	// ******************************
 
 	// create a new pool
 	function create(objectFactory = ()=>({})) {
 		var freePool = [];
-    var freePoolEnd = -1;
+		var freePoolEnd = -1;
 		
-    return {
+		return {
 			use,
 			recycle,
 			grow,
@@ -29,25 +29,25 @@
 		// ******************************
 
 		function use() {
-      if (freePoolEnd == -1) {
-        if (freePool.length == 0) {
-          grow(5);
-        } else {
-          grow();
-        }
-      }
-      return freePool[freePool.length - (freePoolEnd--)];
+			if (freePoolEnd == -1) {
+				if (freePool.length == 0) {
+					grow(5);
+				} else {
+					grow();
+				}
+			}
+			return freePool[freePool.length - 1 - (freePoolEnd--)];
 		}
 
 		function recycle(obj) {
-      freePool[freePool.length - (++freePoolEnd)] = obj;
+			freePool[freePool.length - (++freePoolEnd)] = obj;
 		}
 
 		function grow(count = freePool.length) {
-      for (var i = 0; i < count; ++i) {
-        freePool[freePool.length] = objectFactory();
-      }
-      freePoolEnd += count;
+			for (var i = 0; i < count; ++i) {
+				freePool[freePool.length] = objectFactory();
+			}
+			freePoolEnd += count;
 			return freePool.length;
 		}
 

--- a/perfs.js
+++ b/perfs.js
@@ -217,4 +217,26 @@ main.add(
 	})
 );
 
+main.add(
+	"use() + recycle(): multiple of each",
+	function p11(){
+		for (var i = 0; i < 1000; ++i) {
+			items[i] = pool.use();
+		}
+		for (var i = 0; i < 1000; ++i) {
+			pool.recycle(items[i]);
+		}
+	},
+	Object.assign(Benchmark.__default_benchmark_options__,{
+		setup: function p11Setup(){
+			var items = [];
+			var pool = deePool.create(makeObj);
+			pool.grow(1E6);
+		},
+		teardown: function p11Teardown(){
+			item = pool = null;
+		},
+	})
+);
+
 main.run();


### PR DESCRIPTION
Just some things to think about (and some poorly written example code)

The original implementation of deePool methods have an O(n) time
complexity (in particular use/recycle).
This change makes those methods O(1) and vastly simplifies the code
It makes the concession of sacrificing ordering while growing the pool
and recycling objects (this is OK as the deePool didn't specify that
there was supposed to be any ordering semantics).

Tests are still busted (due to them relying on un-specified ordering
semantics) but functionally all works.
Also forgive the tabs/spaces mismatch. 

Here's the difference in perf numbers:
Original implementation:
```
deePool Performance Benchmarks
deePool.create()... complete: 6,644,319 ops/sec (391771 samples)
use() + recycle(): small pool (10)... complete: 9,704,383 ops/sec (533343 samples)
use() + recycle(): medium pool (10,000)... complete: 14,060 ops/sec (726 samples)
use() + recycle(): large pool (1,000,000)... complete: 132 ops/sec (7 samples)
use(): growing pool... complete: 2,662,634 ops/sec (397408 samples)
grow(): small increments... complete: 4,825 ops/sec (5000 samples)
grow(): medium increments... complete: 1,395 ops/sec (150 samples)
grow(): large increments... complete: 92 ops/sec (90 samples)
grow(): exponential (doubling)... complete: 49 ops/sec (19 samples)
use() + recycle(): interleaved... complete: 1,851,973 ops/sec (203786 samples)
use() + recycle(): multiple of each... <doesn't finish in reasonable time...>
```

0(1) implementation:
```
deePool Performance Benchmarks
deePool.create()... complete: 7,929,288 ops/sec (414483 samples)
use() + recycle(): small pool... complete: 44,645,133 ops/sec (2362781 samples)
use() + recycle(): medium pool... complete: 41,821,068 ops/sec (2356688 samples)
use() + recycle(): large pool... complete: 41,899,579 ops/sec (2416356 samples)
use(): growing pool... complete: 2,555,250 ops/sec (238327 samples)
grow(): small increments... complete: 708,790 ops/sec (162082 samples)
grow(): medium increments... complete: 7,729 ops/sec (2504 samples)
grow(): large increments... complete: 367 ops/sec (90 samples)
grow(): exponential (doubling)... complete: 65 ops/sec (19 samples)
use() + recycle(): interleaved... complete: 2,192,863 ops/sec (245557 samples)
use() + recycle(): multiple of each... complete: 35,301 ops/sec (5000 samples)
```

Note the perf decrease on `use() + recycle()` as the pool gets larger in the original implementation.
The ops/sec drop is almost exactly linear with respect the increase in pool size (indicating O(n))